### PR TITLE
fix: 首页日刊显示最新期号而非文章发布日期

### DIFF
--- a/src/lib/clippings.ts
+++ b/src/lib/clippings.ts
@@ -19,6 +19,24 @@ export type EditionGroup = {
 	latestDate: Date;
 };
 
+/** Sort key for edition identifiers (newer editions sort higher). */
+export function editionSortKey(edition: string, type: EditionType): number {
+	if (type === 'daily') {
+		return new Date(`${edition}T12:00:00`).getTime();
+	}
+
+	const match = edition.match(/^(\d{4})-w(\d{1,2})$/i);
+	if (match) {
+		return Number(match[1]) * 100 + Number(match[2]);
+	}
+
+	return 0;
+}
+
+export function compareEditionGroups(a: EditionGroup, b: EditionGroup): number {
+	return editionSortKey(b.edition, b.type) - editionSortKey(a.edition, a.type);
+}
+
 export function groupByEdition(clippings: Clipping[]): EditionGroup[] {
 	const groups = new Map<string, Clipping[]>();
 
@@ -41,11 +59,11 @@ export function groupByEdition(clippings: Clipping[]): EditionGroup[] {
 				latestDate: sorted[0].data.pubDate,
 			};
 		})
-		.sort((a, b) => b.latestDate.valueOf() - a.latestDate.valueOf());
+		.sort(compareEditionGroups);
 }
 
 export function getEditionsByType(groups: EditionGroup[], type: EditionType): EditionGroup[] {
-	return groups.filter((group) => group.type === type);
+	return groups.filter((group) => group.type === type).sort(compareEditionGroups);
 }
 
 export function formatEditionTitle(edition: string, type: EditionType): string {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

首页「日刊」区块一直显示 **2026年7月5日**，而不是最新的 **7月8日** 期。

## 原因

`groupByEdition()` 按期内的 `pubDate`（原文发布日期）排序，而不是按 `edition` 期号排序。例如 `managed-agents.md` 的 `edition` 是 `2026-07-08`，但 `pubDate` 是 `2026-04-08`，导致排序时被更早的期号压过；而 `ai-code-review-tips.md` 的 `pubDate` 恰好是 `2026-07-05`，于是 7 月 5 日总排在最前。

## 修复

- 新增 `editionSortKey()` / `compareEditionGroups()`，按 `edition` 标识排序（日刊 `YYYY-MM-DD`，周刊 `YYYY-wNN`）
- `groupByEdition()` 与 `getEditionsByType()` 均使用该比较器，保证首页、日刊列表、周刊列表都显示最新期

## 验证

- `npm run build` 通过
- 构建后的首页标题为「AI 日刊 · 2026年7月8日」
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f443d-7f4c-740a-b556-c284b0f61f9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f443d-7f4c-740a-b556-c284b0f61f9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

